### PR TITLE
refactor(Stacktrace): Add original stack trace when an error happens to the callers AB#6032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.5.0
+- Added stacktrace support to error handling functions
+- Updated `withError`, `withErrorAsync`, `match`, and `fold` to include stacktrace parameter
+- Added automatic stacktrace capture in `runCatching` and `runCatchingAsync`
+- Added stacktrace example in `example/stacktrace_example.dart`
+- Added comprehensive tests to verify stacktrace capture and propagation
+- Added tests to verify that stacktraces correctly point to the line that threw the exception
+
 ## 2.4.0
 - Allow const constructors
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Result Monad
-This is a fork from [HankG/dart-result-monad](https://gitlab.com/HankG/dart-result-monad/) for which we are 
+This is a fork from [HankG/dart-result-monad](https://gitlab.com/HankG/dart-result-monad/) for which we are
 grateful. I have added some features and fixed some bugs.
 
 # Docs
@@ -24,12 +24,13 @@ various aspects of the implementation for this library.
 * `withResult` and `withResultAsync` for processing results in a pass-through capability with
   short-circuiting on thrown exceptions
 * `withError` and `withErrorAsync` for processing errors in a pass-through capability with
-  short-circuiting on thrown exceptions
+  short-circuiting on thrown exceptions, including stacktrace information
 * `mapValue`, `mapError`, `errorCast` methods for transforming success and failure types
 * `match` method for performing different operations on a success or failure
-  monad
+  monad, with stacktrace information for errors
 * `fold` method for transforming the monad into a new result type with different
-  logic for
+  logic for success and error cases, including stacktrace information for errors
+* Automatic stacktrace capture when using `runCatching` and `runCatchingAsync`
 
 ## Getting started
 
@@ -37,7 +38,7 @@ In the `pubspec.yaml` of your Dart/Flutter project, add the following dependency
 
 ```yaml
 dependencies:
-  result_monad: ^2.3.2
+  result_monad: ^2.5.0
 ```
 
 In your source code add the following import:
@@ -65,14 +66,47 @@ void main() {
   // Prints 'Inverse is: 0.5'
   invert(2).match(
       onSuccess: (value) => print("Inverse is: $value"),
-      onError: (error) => print(error));
+      onError: (error, stackTrace) => print(error));
 
   // Prints 'Cannot invert zero'
   invert(0).match(
       onSuccess: (value) => print("Inverse is: $value"),
-      onError: (error) => print(error));
+      onError: (error, stackTrace) => print(error));
 }
 ```
+
+## Stacktrace Support
+
+The Result monad now includes stacktrace support for error handling. This allows you to capture and access the stacktrace where an error occurred, making debugging easier.
+
+```dart
+// Create an error with a stacktrace
+try {
+  // Some code that might throw
+  throw Exception('Something went wrong');
+} catch (e, stackTrace) {
+  return Result.error(e, stackTrace);
+}
+
+// Access the stacktrace in error handlers
+result.match(
+  onSuccess: (value) => print('Success: $value'),
+  onError: (error, stackTrace) {
+    print('Error: $error');
+    if (stackTrace != null) {
+      print('StackTrace: $stackTrace');
+    }
+  },
+);
+
+// Automatic stacktrace capture with runCatching
+final result = runCatching(() {
+  // Code that might throw
+  return someRiskyOperation();
+});
+```
+
+See the `example/stacktrace_example.dart` file for more examples of using stacktrace information.
 
 ## Additional information
 

--- a/example/stacktrace_example.dart
+++ b/example/stacktrace_example.dart
@@ -1,0 +1,145 @@
+import 'package:result_monad/result_monad.dart';
+
+/// This example demonstrates how to use the stacktrace information
+/// with the Result monad's error handling functions.
+
+// Example of manually creating an error without a stacktrace
+Result<int, String> divideNumbers(int a, int b) {
+  if (b == 0) {
+    return Result.error('Cannot divide by zero');
+  }
+  return Result.ok(a ~/ b);
+}
+
+// Example of manually creating an error with a stacktrace
+Result<int, String> divideNumbersWithStacktrace(int a, int b) {
+  if (b == 0) {
+    // Capture the current stacktrace when creating the error
+    return Result.error('Cannot divide by zero', StackTrace.current);
+  }
+  return Result.ok(a ~/ b);
+}
+
+// Example of catching an exception and preserving its stacktrace
+Result<int, Exception> causeException() {
+  try {
+    // This will cause a RangeError
+    final list = [1, 2, 3];
+    return Result.ok(list[10]);
+  } catch (e, stackTrace) {
+    // Capture both the exception and the stacktrace
+    return Result.error(Exception('Index out of range'), stackTrace);
+  }
+}
+
+void main() {
+  print('Example 1: Error without stacktrace - Using withError');
+  divideNumbers(10, 0).withError((error, stackTrace) {
+    print('Error: $error');
+    if (stackTrace != null) {
+      print('StackTrace: $stackTrace');
+    } else {
+      print('No stacktrace available');
+    }
+  });
+
+  print('\nExample 2: Error with stacktrace - Using withError');
+  divideNumbersWithStacktrace(10, 0).withError((error, stackTrace) {
+    print('Error: $error');
+    if (stackTrace != null) {
+      print('StackTrace: $stackTrace');
+    } else {
+      print('No stacktrace available');
+    }
+  });
+
+  print('\nExample 3: Error without stacktrace - Using match');
+  divideNumbers(10, 0).match(
+    onSuccess: (value) => print('Result: $value'),
+    onError: (error, stackTrace) {
+      print('Error: $error');
+      if (stackTrace != null) {
+        print('StackTrace: $stackTrace');
+      } else {
+        print('No stacktrace available');
+      }
+    },
+  );
+
+  print('\nExample 4: Error with stacktrace - Using match');
+  divideNumbersWithStacktrace(10, 0).match(
+    onSuccess: (value) => print('Result: $value'),
+    onError: (error, stackTrace) {
+      print('Error: $error');
+      if (stackTrace != null) {
+        print('StackTrace: $stackTrace');
+      } else {
+        print('No stacktrace available');
+      }
+    },
+  );
+
+  print('\nExample 5: Error without stacktrace - Using fold');
+  final result1 = divideNumbers(10, 0).fold(
+    onSuccess: (value) => 'Success: $value',
+    onError: (error, stackTrace) => 'Error: $error${stackTrace != null ? '\nStackTrace: $stackTrace' : ''}',
+  );
+  print(result1);
+
+  print('\nExample 6: Error with stacktrace - Using fold');
+  final result2 = divideNumbersWithStacktrace(10, 0).fold(
+    onSuccess: (value) => 'Success: $value',
+    onError: (error, stackTrace) => 'Error: $error${stackTrace != null ? '\nStackTrace: $stackTrace' : ''}',
+  );
+  print(result2);
+
+  print('\nExample 7: Caught exception with stacktrace');
+  causeException().match(
+    onSuccess: (value) => print('Result: $value'),
+    onError: (error, stackTrace) {
+      print('Error: $error');
+      if (stackTrace != null) {
+        print('StackTrace: $stackTrace');
+      } else {
+        print('No stacktrace available');
+      }
+    },
+  );
+
+  print('\nExample 8: Using runCatching to automatically capture stacktrace');
+  final caughtResult = runCatching(() {
+    final list = [1, 2, 3];
+    return Result.ok(list[10]);
+  });
+
+  caughtResult.match(
+    onSuccess: (value) => print('Result: $value'),
+    onError: (error, stackTrace) {
+      print('Error: $error');
+      if (stackTrace != null) {
+        print('StackTrace: $stackTrace');
+      } else {
+        print('No stacktrace available');
+      }
+    },
+  );
+
+  print('\nExample 9: Using runCatchingAsync to automatically capture stacktrace');
+  runCatchingAsync(() async {
+    await Future.delayed(Duration(milliseconds: 100));
+    final list = [1, 2, 3];
+    return Result.ok(list[10]);
+  }).then((result) {
+    result.match(
+      onSuccess: (value) => print('Result: $value'),
+      onError: (error, stackTrace) {
+        print('Error: $error');
+        if (stackTrace != null) {
+          print('StackTrace: $stackTrace');
+        } else {
+          print('No stacktrace available');
+        }
+      },
+    );
+  });
+}

--- a/lib/src/future_result_extensions.dart
+++ b/lib/src/future_result_extensions.dart
@@ -61,18 +61,18 @@ extension FutureResultExtension<T, E> on Future<Result<T, E>> {
       (await this).withResultAsync(withFunction);
 
   /// See documentation for the [Result.withError] method.
-  FutureResult<T, dynamic> withError(Function(E) withFunction) async =>
+  FutureResult<T, dynamic> withError(Function(E, StackTrace?) withFunction) async =>
       (await this).withError(withFunction);
 
   /// See documentation for the [Result.withErrorAsync] method.
   FutureResult<T, dynamic> withErrorAsync(
-          Future<void> Function(E) withFunction) async =>
+          Future<void> Function(E, StackTrace?) withFunction) async =>
       (await this).withErrorAsync(withFunction);
 
   /// See documentation for the [Result.match] method.
   Future<void> match(
           {required Function(T value) onSuccess,
-          required Function(E error) onError}) async =>
+          required Function(E error, StackTrace? stackTrace) onError}) async =>
       (await this).match(
         onSuccess: onSuccess,
         onError: onError,
@@ -81,7 +81,7 @@ extension FutureResultExtension<T, E> on Future<Result<T, E>> {
   /// See documentation for the [Result.fold] method.
   Future<T2> fold<T2>(
           {required T2 Function(T value) onSuccess,
-          required T2 Function(E error) onError}) async =>
+          required T2 Function(E error, StackTrace? stackTrace) onError}) async =>
       (await this).fold(
         onSuccess: onSuccess,
         onError: onError,

--- a/lib/src/result_monad_base.dart
+++ b/lib/src/result_monad_base.dart
@@ -14,7 +14,7 @@ abstract class Result<T, E> {
   ///
   /// Optionally, you can provide a stackTrace to track where the error occurred.
   /// If not provided, the current stacktrace will be captured.
-  factory Result.error(E error, [StackTrace? stackTrace]) = Error;
+  const factory Result.error(E error, [StackTrace? stackTrace]) = Error;
 
   /// Create a new Result of the expected success type with the success value
   /// `Result<int,String> getSuccess() => Result.ok(10);`

--- a/lib/src/result_monad_exception_wrapping.dart
+++ b/lib/src/result_monad_exception_wrapping.dart
@@ -16,16 +16,16 @@ import '../result_monad.dart';
 /// });
 ///
 /// sizeResult.match(
-///   (size) => print('File size: $size'),
-///   (error) => print('Error accessing $filename: $error')
+///   onSuccess: (size) => print('File size: $size'),
+///   onError: (error, stackTrace) => print('Error accessing $filename: $error\n$stackTrace')
 /// );
 /// ```
 ///
 Result<T, dynamic> runCatching<T>(Result<T, dynamic> Function() function) {
   try {
     return function();
-  } catch (e) {
-    return Result.error(e);
+  } catch (e, stackTrace) {
+    return Result.error(e, stackTrace);
   }
 }
 
@@ -43,8 +43,8 @@ Result<T, dynamic> runCatching<T>(Result<T, dynamic> Function() function) {
 /// });
 ///
 /// sizeResult.match(
-///   (size) => print('File size: $size'),
-///   (error) => print('Error accessing $filename: $error')
+///   onSuccess: (size) => print('File size: $size'),
+///   onError: (error, stackTrace) => print('Error accessing $filename: $error\n$stackTrace')
 /// );
 /// ```
 ///
@@ -52,7 +52,7 @@ FutureResult<T, dynamic> runCatchingAsync<T>(
     FutureResult<T, dynamic> Function() function) async {
   try {
     return await function();
-  } catch (e) {
-    return Result.error(e);
+  } catch (e, stackTrace) {
+    return Result.error(e, stackTrace);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: result_monad
 description: A Dart implementation of the Result Monad which allows for more expressive result generation and processing without using exceptions.
-version: 2.4.0
+version: 2.5.0
 homepage: https://github.com/NEONSCREENS/flutter-result-monad
 
 environment:

--- a/test/future_result_extensions_test.dart
+++ b/test/future_result_extensions_test.dart
@@ -444,26 +444,26 @@ void main() {
     test('Test simple pass through', () async {
       var resultString1 = '';
       final result = await buildFutureError('Error')
-          .withError((value) => resultString1 = value);
+          .withError((value, _) => resultString1 = value);
       expect(result.error, equals('Error'));
       expect(resultString1, equals('Error'));
     });
     test('Test success skips', () async {
       var resultString1 = 'Skipped';
       final result = await buildFutureSuccess('Success')
-          .withError((value) => resultString1 = value);
+          .withError((value, _) => resultString1 = value);
       expect(result.isSuccess, equals(true));
       expect(resultString1, equals('Skipped'));
     });
     test('Test pass through mutation does not propagate', () async {
       final result =
-          await buildFutureError('Error').withError((value) => value = 'Hello');
+          await buildFutureError('Error').withError((value, _) => value = 'Hello');
       expect(result.error, equals('Error'));
     });
     test('Test exception thrown generates propagated error or new type',
         () async {
       final result = await buildFutureError('Error')
-          .withError((value) => throw Exception('New Error'));
+          .withError((value, _) => throw Exception('New Error'));
       expect(result.isFailure, equals(true));
       expect(result.error.message, equals('New Error'));
     });
@@ -473,26 +473,26 @@ void main() {
     test('Test simple pass through', () async {
       var resultString1 = '';
       final result = await buildFutureError('Error')
-          .withErrorAsync((value) async => resultString1 = value);
+          .withErrorAsync((value, _) async => resultString1 = value);
       expect(result.error, equals('Error'));
       expect(resultString1, equals('Error'));
     });
     test('Test success skips', () async {
       var resultString1 = 'Skipped';
       final result = await buildFutureSuccess('Success')
-          .withErrorAsync((value) async => resultString1 = value);
+          .withErrorAsync((value, _) async => resultString1 = value);
       expect(result.isSuccess, equals(true));
       expect(resultString1, equals('Skipped'));
     });
     test('Test pass through mutation does not propagate', () async {
       final result = await buildFutureError('Error')
-          .withErrorAsync((value) async => value = 'Hello');
+          .withErrorAsync((value, _) async => value = 'Hello');
       expect(result.error, equals('Error'));
     });
     test('Test exception thrown generates propagated error or new type',
         () async {
       final result = await buildFutureError('Error')
-          .withErrorAsync((value) async => throw Exception('New Error'));
+          .withErrorAsync((value, _) async => throw Exception('New Error'));
       expect(result.isFailure, equals(true));
       expect(result.error.message, equals('New Error'));
     });
@@ -505,21 +505,21 @@ void main() {
     test('Regular types', () async {
       await buildFutureSuccess(expectedSuccess).match(
           onSuccess: (value) => expect(value, equals(expectedSuccess)),
-          onError: (error) => fail("Shouldn't execute this path"));
+          onError: (error, _) => fail("Shouldn't execute this path"));
 
       await buildFutureError(expectedFailure).match(
           onSuccess: (value) => fail("Shouldn't execute this path"),
-          onError: (error) => expect(error, equals(expectedFailure)));
+          onError: (error, _) => expect(error, equals(expectedFailure)));
     });
 
     test('Nullable Types', () async {
       await buildFutureSuccess(expectedSuccess).match(
           onSuccess: (value) => expect(value, equals(expectedSuccess)),
-          onError: (error) => fail("Shouldn't execute this path"));
+          onError: (error, _) => fail("Shouldn't execute this path"));
 
       await buildFutureError(expectedFailure).match(
           onSuccess: (value) => fail("Shouldn't execute this path"),
-          onError: (error) => expect(error, equals(expectedFailure)));
+          onError: (error, _) => expect(error, equals(expectedFailure)));
     });
   });
 
@@ -529,23 +529,23 @@ void main() {
 
     test('Regular Types', () async {
       final successFolded = await buildFutureSuccess(expectedSuccess)
-          .fold(onSuccess: (value) => value, onError: (error) => 'error');
+          .fold(onSuccess: (value) => value, onError: (error, stack) => 'error');
       expect(successFolded, equals(expectedSuccess));
 
       final failedFolded = await buildFutureError(100)
-          .fold(onSuccess: (value) => 0, onError: (error) => error);
+          .fold(onSuccess: (value) => 0, onError: (error, stack) => error);
       expect(failedFolded, equals(expectedFailure));
     });
 
     test('Nullable Types', () async {
       final successFolded = await buildFutureSuccess(expectedSuccess)
           .andThenSuccessAsync((p0) async => p0)
-          .fold(onSuccess: (value) => value, onError: (error) => 'error');
+          .fold(onSuccess: (value) => value, onError: (error, stack) => 'error');
       expect(successFolded, equals(expectedSuccess));
 
       final failedFolded = await buildFutureError(100)
           .andThenSuccessAsync((p0) async => p0)
-          .fold(onSuccess: (value) => 0, onError: (error) => error);
+          .fold(onSuccess: (value) => 0, onError: (error, stack) => error);
       expect(failedFolded, equals(expectedFailure));
       expect(failedFolded, equals(expectedFailure));
     });

--- a/test/stacktrace_line_test.dart
+++ b/test/stacktrace_line_test.dart
@@ -1,0 +1,96 @@
+import 'package:result_monad/result_monad.dart';
+import 'package:test/test.dart';
+
+// This class is used to test that the stacktrace points to the correct line
+class ErrorThrower {
+  // This method will throw an exception
+  static Result<int, Exception> throwError() {
+    // This line number is important for the test
+    throw Exception('Test exception');
+  }
+  
+  // This method will catch the exception and return a Result
+  static Result<int, Exception> catchError() {
+    try {
+      return throwError();
+    } catch (e, stackTrace) {
+      return Result.error(Exception('Caught exception'), stackTrace);
+    }
+  }
+  
+  // This method will use runCatching to catch the exception
+  static Result<int, dynamic> runCatchingError() {
+    return runCatching(() {
+      // This will call the method that throws
+      return throwError();
+    });
+  }
+}
+
+void main() {
+  group('Stacktrace Line Tests', () {
+    test('Stacktrace from manually caught exception should point to the throw line', () {
+      final result = ErrorThrower.catchError();
+      
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<Exception>());
+      expect(result.stackTrace, isNotNull);
+      
+      // Verify the stacktrace contains the file and line number of the throw
+      final stackTraceString = result.stackTrace.toString();
+      expect(stackTraceString.contains('stacktrace_line_test.dart'), isTrue);
+      
+      // The line number should be close to the throw statement in throwError
+      final fileLinePattern = RegExp(r'stacktrace_line_test.dart:(\d+)');
+      final matches = fileLinePattern.allMatches(stackTraceString).toList();
+      
+      // We should have at least one match
+      expect(matches.isNotEmpty, isTrue);
+      
+      // Find the line number of the throw statement
+      bool foundThrowLine = false;
+      for (final match in matches) {
+        final lineNumber = int.parse(match.group(1)!);
+        // The throw is on line 8 (or close to it)
+        if (lineNumber >= 7 && lineNumber <= 9) {
+          foundThrowLine = true;
+          break;
+        }
+      }
+      
+      expect(foundThrowLine, isTrue, reason: 'Stacktrace should contain the line where the exception was thrown');
+    });
+    
+    test('Stacktrace from runCatching should point to the throw line', () {
+      final result = ErrorThrower.runCatchingError();
+      
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<Exception>());
+      expect(result.stackTrace, isNotNull);
+      
+      // Verify the stacktrace contains the file and line number of the throw
+      final stackTraceString = result.stackTrace.toString();
+      expect(stackTraceString.contains('stacktrace_line_test.dart'), isTrue);
+      
+      // The line number should be close to the throw statement in throwError
+      final fileLinePattern = RegExp(r'stacktrace_line_test.dart:(\d+)');
+      final matches = fileLinePattern.allMatches(stackTraceString).toList();
+      
+      // We should have at least one match
+      expect(matches.isNotEmpty, isTrue);
+      
+      // Find the line number of the throw statement
+      bool foundThrowLine = false;
+      for (final match in matches) {
+        final lineNumber = int.parse(match.group(1)!);
+        // The throw is on line 8 (or close to it)
+        if (lineNumber >= 7 && lineNumber <= 9) {
+          foundThrowLine = true;
+          break;
+        }
+      }
+      
+      expect(foundThrowLine, isTrue, reason: 'Stacktrace should contain the line where the exception was thrown');
+    });
+  });
+}

--- a/test/stacktrace_test.dart
+++ b/test/stacktrace_test.dart
@@ -1,0 +1,157 @@
+import 'package:result_monad/result_monad.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Stacktrace Tests', () {
+    test('Result.error should accept a stacktrace', () {
+      final stackTrace = StackTrace.current;
+      final result = Result.error('Error message', stackTrace);
+
+      expect(result.isFailure, isTrue);
+      expect(result.error, equals('Error message'));
+      expect(result.stackTrace, equals(stackTrace));
+    });
+
+    test('Result.error should have null stacktrace when not provided', () {
+      final result = Result.error('Error message');
+
+      expect(result.isFailure, isTrue);
+      expect(result.error, equals('Error message'));
+      expect(result.stackTrace, isNull);
+    });
+
+    test('runCatching should capture stacktrace from thrown exception', () {
+      final result = runCatching(() {
+        // This line number is important for the test below
+        throw Exception('Test exception');
+      });
+
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<Exception>());
+      expect(result.stackTrace, isNotNull);
+
+      // Verify the stacktrace contains this file and line number
+      final stackTraceString = result.stackTrace.toString();
+      expect(stackTraceString.contains('stacktrace_test.dart'), isTrue);
+
+      // The line number should be close to the throw statement
+      final fileLinePattern = RegExp(r'stacktrace_test.dart:(\d+)');
+      final match = fileLinePattern.firstMatch(stackTraceString);
+      expect(match, isNotNull);
+
+      if (match != null) {
+        final lineNumber = int.parse(match.group(1)!);
+        // The line number should be close to the throw statement
+        // We use a range because the exact line might change with edits
+        expect(lineNumber, greaterThan(10));
+        expect(lineNumber, lessThan(30));
+      }
+    });
+
+    test('runCatchingAsync should capture stacktrace from thrown exception', () async {
+      final result = await runCatchingAsync(() async {
+        // This line number is important for the test below
+        throw Exception('Test async exception');
+      });
+
+      expect(result.isFailure, isTrue);
+      expect(result.error, isA<Exception>());
+      expect(result.stackTrace, isNotNull);
+
+      // Verify the stacktrace contains this file and line number
+      final stackTraceString = result.stackTrace.toString();
+      expect(stackTraceString.contains('stacktrace_test.dart'), isTrue);
+
+      // The line number should be close to the throw statement
+      final fileLinePattern = RegExp(r'stacktrace_test.dart:(\d+)');
+      final match = fileLinePattern.firstMatch(stackTraceString);
+      expect(match, isNotNull);
+
+      if (match != null) {
+        final lineNumber = int.parse(match.group(1)!);
+        // The line number should be close to the throw statement
+        // We use a range because the exact line might change with edits
+        expect(lineNumber, greaterThan(35));
+        expect(lineNumber, lessThan(60));
+      }
+    });
+
+    test('withError should pass stacktrace to callback', () {
+      bool stackTraceReceived = false;
+      final stackTrace = StackTrace.current;
+
+      Result.error('Error message', stackTrace).withError((error, st) {
+        expect(error, equals('Error message'));
+        expect(st, equals(stackTrace));
+        stackTraceReceived = true;
+      });
+
+      expect(stackTraceReceived, isTrue);
+    });
+
+    test('withErrorAsync should pass stacktrace to callback', () async {
+      bool stackTraceReceived = false;
+      final stackTrace = StackTrace.current;
+
+      await Result.error('Error message', stackTrace).withErrorAsync((error, st) async {
+        expect(error, equals('Error message'));
+        expect(st, equals(stackTrace));
+        stackTraceReceived = true;
+      });
+
+      expect(stackTraceReceived, isTrue);
+    });
+
+    test('match should pass stacktrace to onError callback', () {
+      bool stackTraceReceived = false;
+      final stackTrace = StackTrace.current;
+
+      Result.error('Error message', stackTrace).match(
+        onSuccess: (value) => fail('Should not call onSuccess'),
+        onError: (error, st) {
+          expect(error, equals('Error message'));
+          expect(st, equals(stackTrace));
+          stackTraceReceived = true;
+        },
+      );
+
+      expect(stackTraceReceived, isTrue);
+    });
+
+    test('fold should pass stacktrace to onError callback', () {
+      bool stackTraceReceived = false;
+      final stackTrace = StackTrace.current;
+
+      final result = Result.error('Error message', stackTrace).fold(
+        onSuccess: (value) => 'Success',
+        onError: (error, st) {
+          expect(error, equals('Error message'));
+          expect(st, equals(stackTrace));
+          stackTraceReceived = true;
+          return 'Error';
+        },
+      );
+
+      expect(stackTraceReceived, isTrue);
+      expect(result, equals('Error'));
+    });
+
+    test('toString should include stacktrace for error results', () {
+      final stackTrace = StackTrace.current;
+      final result = Result.error('Error message', stackTrace);
+
+      final stringRepresentation = result.toString();
+      expect(stringRepresentation.contains('error(Error message)'), isTrue);
+      expect(stringRepresentation.contains('StackTrace:'), isTrue);
+      expect(stringRepresentation.contains(stackTrace.toString()), isTrue);
+    });
+
+    test('toString should not include stacktrace for success results', () {
+      final result = Result.ok('Success message');
+
+      final stringRepresentation = result.toString();
+      expect(stringRepresentation, equals('ok(Success message)'));
+      expect(stringRepresentation.contains('StackTrace:'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Current
We just get the error on `withError` and others

# Expected
We get the stacktrace too thanks to this change on the library:
- https://github.com/NEONSCREENS/flutter-result-monad/pull/2