### PR TITLE
feat(test): Add result_monad_test package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,22 @@ jobs:
     
     - name: Run tests
       run: dart test --platform vm --timeout 30s --concurrency=6 --test-randomize-ordering-seed=random --reporter=expanded
-   publish:
-     needs: test
-     runs-on: ubuntu-latest
-     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-     steps:
-     - name: Checkout code
-       uses: actions/checkout@v4
 
-     - name: Setup Dart SDK
-       uses: dart-lang/setup-dart@v1
-       with:
-         sdk: stable
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-     - name: Install dependencies
-       run: dart pub get
+    - name: Setup Dart SDK
+      uses: dart-lang/setup-dart@v1
+      with:
+        sdk: stable
 
-     - name: Publish to pub.dev
-       run: dart pub publish --dry-run
+    - name: Install dependencies
+      run: dart pub get
+
+    - name: Publish to pub.dev
+      run: dart pub publish --dry-run

--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ final result = runCatching(() {
 
 See the `example/stacktrace_example.dart` file for more examples of using stacktrace information.
 
+## Test Matchers
+
+The companion package [`result_monad_test`](result_monad_test/) provides `isOk` and `isError` matchers for expressive assertions in tests.
+
+```yaml
+dev_dependencies:
+  result_monad_test: ^1.0.0
+```
+
+```dart
+import 'package:result_monad_test/result_monad_test.dart';
+
+expect(result, isOk(42));
+expect(result, isError('not found'));
+expect(result, isOk<int>().having((r) => r.value, 'value', greaterThan(0)));
+```
+
 ## Additional information
 
 This result monad implementation takes inspiration from the

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,15 +13,15 @@
 
 include: package:lints/recommended.yaml
 
+analyzer:
+  exclude:
+    - result_monad_test/**
+
 # Uncomment the following section to specify additional rules.
 
 # linter:
 #   rules:
 #     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
 
 # For more information about the core and recommended set of lints, see
 # https://dart.dev/go/core-lints

--- a/result_monad_test/CHANGELOG.md
+++ b/result_monad_test/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.0.0
+
+- Initial release
+- `isOk<T>()` matcher — asserts `Result` is `Ok`, optional value equality, generic type narrowing
+- `isError<E>()` matcher — asserts `Result` is `Error`, optional cause equality, generic type narrowing
+- Pure Dart — depends on `package:matcher`, not `flutter_test`
+- Compatible with both `package:test` and `package:flutter_test`

--- a/result_monad_test/LICENSE
+++ b/result_monad_test/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, HankG
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/result_monad_test/README.md
+++ b/result_monad_test/README.md
@@ -1,0 +1,63 @@
+# result_monad_test
+
+Test matchers for the [result_monad](https://github.com/NEONSCREENS/flutter-result-monad) package. Provides `isOk` and `isError` matchers for expressive `Result` assertions.
+
+Pure Dart — works with both `package:test` and `package:flutter_test`.
+
+## Install
+
+```yaml
+dev_dependencies:
+  result_monad_test: ^1.0.0
+```
+
+## Usage
+
+```dart
+import 'package:result_monad/result_monad.dart';
+import 'package:result_monad_test/result_monad_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('basic matchers', () {
+    final ok = Result<int, String>.ok(42);
+    final err = Result<int, String>.error('not found');
+
+    // Type check only
+    expect(ok, isOk());
+    expect(err, isError());
+
+    // Value/cause equality
+    expect(ok, isOk(42));
+    expect(err, isError('not found'));
+
+    // Generic type narrowing
+    expect(ok, isOk<int>());
+    expect(err, isError<String>());
+
+    // Chained assertions via .having()
+    expect(ok, isOk<int>().having((r) => r.value, 'value', greaterThan(0)));
+    expect(err, isError<String>().having((r) => r.cause, 'cause', contains('not')));
+  });
+}
+```
+
+### `isOk<T>([Object? expected])`
+
+Returns a `TypeMatcher<Ok<T, dynamic>>`. `T` is the **success** type.
+
+| Call | Asserts |
+|------|---------|
+| `isOk()` | Result is `Ok` |
+| `isOk(42)` | Result is `Ok` with `value == 42` |
+| `isOk<int>()` | Result is `Ok<int, dynamic>` |
+
+### `isError<E>([Object? expected])`
+
+Returns a `TypeMatcher<Error<dynamic, E>>`. `E` is the **error** type.
+
+| Call | Asserts |
+|------|---------|
+| `isError()` | Result is `Error` |
+| `isError('fail')` | Result is `Error` with `cause == 'fail'` |
+| `isError<String>()` | Result is `Error<dynamic, String>` |

--- a/result_monad_test/analysis_options.yaml
+++ b/result_monad_test/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/result_monad_test/example/example.dart
+++ b/result_monad_test/example/example.dart
@@ -1,0 +1,26 @@
+import 'package:result_monad/result_monad.dart';
+import 'package:result_monad_test/result_monad_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('isOk matches success results', () {
+    final result = Result<int, String>.ok(42);
+
+    expect(result, isOk());
+    expect(result, isOk(42));
+    expect(result, isOk<int>());
+    expect(result, isOk<int>().having((r) => r.value, 'value', greaterThan(0)));
+  });
+
+  test('isError matches failure results', () {
+    final result = Result<int, String>.error('not found');
+
+    expect(result, isError());
+    expect(result, isError('not found'));
+    expect(result, isError<String>());
+    expect(
+      result,
+      isError<String>().having((r) => r.cause, 'cause', contains('not')),
+    );
+  });
+}

--- a/result_monad_test/lib/result_monad_test.dart
+++ b/result_monad_test/lib/result_monad_test.dart
@@ -1,0 +1,18 @@
+/// Test matchers and utilities for the result_monad package.
+///
+/// Provides [isOk] and [isError] matchers for expressive Result assertions
+/// in tests.
+///
+/// ```dart
+/// import 'package:result_monad_test/result_monad_test.dart';
+///
+/// expect(result, isOk());
+/// expect(result, isOk(42));
+/// expect(result, isOk<int>().having((r) => r.value, 'value', greaterThan(0)));
+///
+/// expect(result, isError());
+/// expect(result, isError('not found'));
+/// ```
+library result_monad_test;
+
+export 'src/matchers.dart';

--- a/result_monad_test/lib/src/matchers.dart
+++ b/result_monad_test/lib/src/matchers.dart
@@ -1,0 +1,40 @@
+import 'package:matcher/matcher.dart';
+import 'package:result_monad/result_monad.dart';
+
+/// Matches a [Result] that is [Ok].
+///
+/// Without argument — asserts only that the result is Ok:
+///   expect(result, isOk());
+///
+/// With [expected] — also asserts value equality:
+///   expect(result, isOk(42));
+///
+/// Chainable with `.having()` for nested checks:
+///   expect(result, isOk<int>()
+///       .having((r) => r.value, 'value', greaterThan(0)));
+TypeMatcher<Ok<T, dynamic>> isOk<T>([Object? expected]) {
+  final matcher = isA<Ok<T, dynamic>>();
+  if (expected != null) {
+    return matcher.having((r) => r.value, 'value', expected);
+  }
+  return matcher;
+}
+
+/// Matches a [Result] that is [Error].
+///
+/// Without argument — asserts only that the result is Error:
+///   expect(result, isError());
+///
+/// With [expected] — also asserts error equality:
+///   expect(result, isError('not found'));
+///
+/// Chainable with `.having()` for nested checks:
+///   expect(result, isError<String>()
+///       .having((r) => r.cause, 'cause', contains('timeout')));
+TypeMatcher<Error<dynamic, T>> isError<T>([Object? expected]) {
+  final matcher = isA<Error<dynamic, T>>();
+  if (expected != null) {
+    return matcher.having((r) => r.cause, 'error', expected);
+  }
+  return matcher;
+}

--- a/result_monad_test/pubspec.yaml
+++ b/result_monad_test/pubspec.yaml
@@ -1,0 +1,21 @@
+name: result_monad_test
+description: Test matchers and utilities for the result_monad package. Provides isOk/isError matchers for expressive Result assertions.
+version: 1.0.0
+homepage: https://github.com/NEONSCREENS/flutter-result-monad
+repository: https://github.com/NEONSCREENS/flutter-result-monad/tree/main/result_monad_test
+issue_tracker: https://github.com/NEONSCREENS/flutter-result-monad/issues
+topics:
+  - result
+  - monad
+  - testing
+
+environment:
+  sdk: '>=2.14.4 <4.0.0'
+
+dependencies:
+  matcher: '>=0.12.11 <1.0.0'
+  result_monad: ^2.5.1
+
+dev_dependencies:
+  lints: ^1.0.1
+  test: ^1.21.4

--- a/result_monad_test/pubspec_overrides.yaml
+++ b/result_monad_test/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  result_monad:
+    path: ../

--- a/result_monad_test/test/matchers_test.dart
+++ b/result_monad_test/test/matchers_test.dart
@@ -1,0 +1,130 @@
+import 'package:result_monad/result_monad.dart';
+import 'package:result_monad_test/result_monad_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isOk', () {
+    test('matches an Ok result', () {
+      final result = Result<int, String>.ok(42);
+      expect(result, isOk());
+    });
+
+    test('does not match an Error result', () {
+      final result = Result<int, String>.error('fail');
+      expect(result, isNot(isOk()));
+    });
+
+    test('matches Ok with expected value', () {
+      final result = Result<String, int>.ok('hello');
+      expect(result, isOk('hello'));
+    });
+
+    test('does not match Ok with wrong value', () {
+      final result = Result<String, int>.ok('hello');
+      expect(result, isNot(isOk('world')));
+    });
+
+    test('matches with generic type parameter', () {
+      final result = Result<int, String>.ok(10);
+      expect(result, isOk<int>());
+    });
+
+    test('does not match wrong generic type', () {
+      final Result<dynamic, String> result = Result.ok('a string');
+      expect(result, isNot(isOk<int>()));
+    });
+
+    test('is chainable with having for nested checks', () {
+      final result = Result<List<int>, String>.ok([1, 2, 3]);
+      expect(
+        result,
+        isOk<List<int>>().having((r) => r.value.length, 'length', 3),
+      );
+    });
+
+    test('works with const results', () {
+      const result = Result<int, String>.ok(0);
+      expect(result, isOk(0));
+    });
+  });
+
+  group('isError', () {
+    test('matches an Error result', () {
+      final result = Result<int, String>.error('fail');
+      expect(result, isError());
+    });
+
+    test('does not match an Ok result', () {
+      final result = Result<int, String>.ok(42);
+      expect(result, isNot(isError()));
+    });
+
+    test('matches Error with expected value', () {
+      final result = Result<int, String>.error('not found');
+      expect(result, isError('not found'));
+    });
+
+    test('does not match Error with wrong value', () {
+      final result = Result<int, String>.error('not found');
+      expect(result, isNot(isError('timeout')));
+    });
+
+    test('matches with generic type parameter', () {
+      final result = Result<int, String>.error('fail');
+      expect(result, isError<String>());
+    });
+
+    test('does not match wrong generic type', () {
+      final Result<int, dynamic> result = Result.error(42);
+      expect(result, isNot(isError<String>()));
+    });
+
+    test('is chainable with having for nested checks', () {
+      final result = Result<int, String>.error('connection timeout');
+      expect(
+        result,
+        isError<String>().having(
+          (r) => r.cause,
+          'cause',
+          contains('timeout'),
+        ),
+      );
+    });
+
+    test('works with const results', () {
+      const result = Result<int, String>.error('err');
+      expect(result, isError('err'));
+    });
+
+    test('preserves stacktrace access in having chain', () {
+      final trace = StackTrace.current;
+      final result = Result<int, String>.error('fail', trace);
+      expect(
+        result,
+        isError<String>().having((r) => r.stackTrace, 'stackTrace', trace),
+      );
+    });
+  });
+
+  group('isOk and isError together', () {
+    test('Ok and Error are mutually exclusive', () {
+      final ok = Result<int, String>.ok(1);
+      final err = Result<int, String>.error('e');
+
+      expect(ok, isOk());
+      expect(ok, isNot(isError()));
+      expect(err, isError());
+      expect(err, isNot(isOk()));
+    });
+
+    test('work with dynamic error type', () {
+      final result = Result.ok(42);
+      expect(result, isOk(42));
+    });
+
+    test('work with dynamic success type', () {
+      final result = Result.error('oops');
+      expect(result, isError('oops'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New `result_monad_test` sub-package with `isOk<T>()` and `isError<E>()` matchers for expressive `Result` assertions
- Pure Dart — depends on `package:matcher`, compatible with both `package:test` and `package:flutter_test`
- Extracted from Neon Music app patterns with corrected `isError<E>` generic (E = error type, not success type)
- 20 tests across 3 groups, all passing
- Publish-ready: LICENSE, CHANGELOG, README, example, pub.dev metadata

## Test plan
- [x] `dart test` — 20/20 pass
- [x] `dart pub publish --dry-run` — 0 warnings, 1 expected hint (local override)
- [x] `dart analyze` — clean
- [ ] Actual publish deferred until parent `result_monad` 2.5.1 is on pub.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)